### PR TITLE
Fix string reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 .vscode/
+res/
+deserialize.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(cerealize C)
+project(cerialize C)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# cerealize
+# cerialize
 
-[![Tests](https://github.com/MankowskiNick/cerealize/actions/workflows/test.yml/badge.svg)](https://github.com/MankowskiNick/cerealize/actions/workflows/test.yml)
+[![Tests](https://github.com/MankowskiNick/cerialize/actions/workflows/test.yml/badge.svg)](https://github.com/MankowskiNick/cerialize/actions/workflows/test.yml)
 
-**cerealize** is a lightweight, single-header JSON deserializer written in C. It provides a simple API for parsing JSON strings into C data structures, with robust error handling and support for core JSON types.
+**cerialize** is a lightweight, single-header JSON deserializer written in C. It provides a simple API for parsing JSON strings into C data structures, with robust error handling and support for core JSON types.
 
 ## Features
 
-- **Single-header library**: Just include `cerealize.h` in your project.
+- **Single-header library**: Just include `cerialize.h` in your project.
 - **Supports core JSON types**: Object, String, Number, Boolean, Null, List (Array).
 - **Strict error handling**: Detailed error messages for invalid input.
 - **Test suite included**: Comprehensive tests for all supported types.
@@ -17,10 +17,10 @@
 
 ### 1. Add to Your Project
 
-Copy `include/cerealize.h` into your project, or reference it directly.
+Copy `include/cerialize.h` into your project, or reference it directly.
 
 ```c
-#include "cerealize.h"
+#include "cerialize.h"
 ```
 
 ### 2. Usage Example
@@ -175,4 +175,4 @@ This project is licensed under the MIT License. You are free to use, modify, and
 
 ---
 
-**For more details, see the code in `include/cerealize.h` and the test suite in `test/`.**
+**For more details, see the code in `include/cerialize.h` and the test suite in `test/`.**

--- a/include/cerialize.h
+++ b/include/cerialize.h
@@ -42,7 +42,7 @@ typedef union json_value {
         bool_t is_null;
         json_list list; // pointer to json_list
         json_body object;
-} json_value;
+} json_value; 
 
 // need to define json_object that tracks the type, and then moodify the lexer to return this
 typedef struct json_object {
@@ -69,7 +69,7 @@ json deserialize_json(const char* json_string, cereal_size_t length);
 
 // lexer
 enum lex_type {
-    LEX_QUOTE = '\'',
+    LEX_QUOTE = '\"',
     LEX_COMMA = ',',
     LEX_PERIOD = '.',
     LEX_OPEN_BRACE = '{',
@@ -112,7 +112,7 @@ char* json_parse_string(const char* json_string, cereal_size_t length, cereal_ui
 
     // opening "'"
     if (json_string[*i] != LEX_QUOTE) {
-        strcat(error_text, "cerealize ERROR: Expected quote to open JSON string.\n");
+        strcat(error_text, "cerialize ERROR: Expected quote to open JSON string.\n");
         *failure = TRUE;
         return NULL;
     }
@@ -125,7 +125,7 @@ char* json_parse_string(const char* json_string, cereal_size_t length, cereal_ui
     cereal_uint_t j = *i;
     do {
         if (j >= length) {
-            strcat(error_text, "cerealize ERROR: Expecting closing quote to close JSON string.\n");
+            strcat(error_text, "cerialize ERROR: Expecting closing quote to close JSON string.\n");
             *failure = TRUE;
             return NULL;
         }
@@ -142,26 +142,27 @@ char* json_parse_string(const char* json_string, cereal_size_t length, cereal_ui
 
     // Reject empty string
     if (str_size == 0) {
-        strcat(error_text, "cerealize ERROR: Empty string not allowed.\n");
+        strcat(error_text, "cerialize ERROR: Empty string not allowed.\n");
         *failure = TRUE;
         return NULL;
     }
     // Reject string with newline inside
     if (found_newline) {
-        strcat(error_text, "cerealize ERROR: Newline in string not allowed.\n");
+        strcat(error_text, "cerialize ERROR: Newline in string not allowed.\n");
         *failure = TRUE;
         return NULL;
     }
 
-    char* str = (char*)malloc(str_size);
+    char* str = (char*)malloc(str_size + 1);  // +1 for null terminator
     for (cereal_uint_t j = 0; j < str_size; j++) {
         str[j] = json_string[*i];
         (*i)++;
     }
+    str[str_size] = '\0';  // Add null terminator
 
     // closing "'"
     if (json_string[*i] != LEX_QUOTE) {
-        strcat(error_text, "cerealize ERROR: Expected closing quote to close JSON string.\n");
+        strcat(error_text, "cerialize ERROR: Expected closing quote to close JSON string.\n");
         *failure = TRUE;
         return NULL;
     }
@@ -173,7 +174,7 @@ char* json_parse_string(const char* json_string, cereal_size_t length, cereal_ui
 bool_t json_parse_null(const char* json_string, cereal_uint_t* i, bool_t* failure, char* error_text) {
     // check for "null"
     if (strncmp(&json_string[*i], "null", 4) != 0) {
-        strcat(error_text, "cerealize ERROR: Expected 'null' keyword.\n");
+        strcat(error_text, "cerialize ERROR: Expected 'null' keyword.\n");
         *failure = TRUE;
         return FALSE;
     }
@@ -185,13 +186,13 @@ bool_t json_parse_null(const char* json_string, cereal_uint_t* i, bool_t* failur
         cereal_uint_t temp_i = *i;
         skip_whitespace(json_string, strlen(json_string), &temp_i);
         if (strncmp(&json_string[temp_i], "null", 4) == 0) {
-            strcat(error_text, "cerealize ERROR: Multiple null values not allowed.\n");
+            strcat(error_text, "cerialize ERROR: Multiple null values not allowed.\n");
             *failure = TRUE;
             return FALSE;
         }
         return TRUE;
     } else {
-        strcat(error_text, "cerealize ERROR: Unexpected characters after 'null'.\n");
+        strcat(error_text, "cerialize ERROR: Unexpected characters after 'null'.\n");
         *failure = TRUE;
         return FALSE;
     }
@@ -205,7 +206,7 @@ float json_parse_number(const char* json_string, cereal_size_t length, cereal_ui
         (*i)++;
         // If another sign immediately follows, it's invalid
         if (*i < length && (json_string[*i] == '-' || json_string[*i] == '+')) {
-            strcat(error_text, "cerealize ERROR: Multiple consecutive signs in number.\n");
+            strcat(error_text, "cerialize ERROR: Multiple consecutive signs in number.\n");
             *failure = TRUE;
             return 0.0f;
         }
@@ -222,7 +223,7 @@ float json_parse_number(const char* json_string, cereal_size_t length, cereal_ui
         if (json_string[*i] == LEX_PERIOD) {
             period_count++;
             if (period_count > 1) {
-                strcat(error_text, "cerealize ERROR: Multiple decimal points in number.\n");
+                strcat(error_text, "cerialize ERROR: Multiple decimal points in number.\n");
                 *failure = TRUE;
                 return 0.0f;
             }
@@ -232,7 +233,7 @@ float json_parse_number(const char* json_string, cereal_size_t length, cereal_ui
             after_e = TRUE;
             // Check for multiple e's
             if (e_count > 1) {
-                strcat(error_text, "cerealize ERROR: Multiple exponents in number.\n");
+                strcat(error_text, "cerialize ERROR: Multiple exponents in number.\n");
                 *failure = TRUE;
                 return 0.0f;
             }
@@ -240,7 +241,7 @@ float json_parse_number(const char* json_string, cereal_size_t length, cereal_ui
         // If after 'e', next must be digit or sign
         if (after_e && (json_string[*i] != 'e' && json_string[*i] != 'E')) {
             if (!(is_number(json_string[*i]) || json_string[*i] == '-' || json_string[*i] == '+')) {
-                strcat(error_text, "cerealize ERROR: Invalid exponent format in number.\n");
+                strcat(error_text, "cerialize ERROR: Invalid exponent format in number.\n");
                 *failure = TRUE;
                 return 0.0f;
             }
@@ -250,13 +251,13 @@ float json_parse_number(const char* json_string, cereal_size_t length, cereal_ui
     }
 
     if (!found_digit) {
-        strcat(error_text, "cerealize ERROR: Expected number.\n");
+        strcat(error_text, "cerialize ERROR: Expected number.\n");
         *failure = TRUE;
         return 0.0f;
     }
     // If last char was 'e' or 'E', fail (incomplete exponent)
     if (*i > start && (json_string[*i-1] == 'e' || json_string[*i-1] == 'E')) {
-        strcat(error_text, "cerealize ERROR: Incomplete exponent in number.\n");
+        strcat(error_text, "cerialize ERROR: Incomplete exponent in number.\n");
         *failure = TRUE;
         return 0.0f;
     }
@@ -268,12 +269,12 @@ float json_parse_number(const char* json_string, cereal_size_t length, cereal_ui
 bool_t json_parse_boolean(const char* json_string, cereal_uint_t* i, bool_t* failure, char* error_text) {
     // Explicitly reject '1' and '0' as booleans
     if (json_string[*i] == '1' && (json_string[*i+1] == '\0' || is_whitespace(json_string[*i+1]) || json_string[*i+1] == ',' || json_string[*i+1] == '}' || json_string[*i+1] == ']')) {
-        strcat(error_text, "cerealize ERROR: '1' is not a valid boolean value.\n");
+        strcat(error_text, "cerialize ERROR: '1' is not a valid boolean value.\n");
         *failure = TRUE;
         return FALSE;
     }
     if (json_string[*i] == '0' && (json_string[*i+1] == '\0' || is_whitespace(json_string[*i+1]) || json_string[*i+1] == ',' || json_string[*i+1] == '}' || json_string[*i+1] == ']')) {
-        strcat(error_text, "cerealize ERROR: '0' is not a valid boolean value.\n");
+        strcat(error_text, "cerialize ERROR: '0' is not a valid boolean value.\n");
         *failure = TRUE;
         return FALSE;
     }
@@ -288,13 +289,13 @@ bool_t json_parse_boolean(const char* json_string, cereal_uint_t* i, bool_t* fai
             cereal_uint_t temp_i = *i;
             skip_whitespace(json_string, strlen(json_string), &temp_i);
             if (strncmp(&json_string[temp_i], "true", 4) == 0 || strncmp(&json_string[temp_i], "false", 5) == 0) {
-                strcat(error_text, "cerealize ERROR: Multiple boolean values not allowed.\n");
+                strcat(error_text, "cerialize ERROR: Multiple boolean values not allowed.\n");
                 *failure = TRUE;
                 return FALSE;
             }
             return TRUE;
         } else {
-            strcat(error_text, "cerealize ERROR: Unexpected characters after 'true'.\n");
+            strcat(error_text, "cerialize ERROR: Unexpected characters after 'true'.\n");
             *failure = TRUE;
             return FALSE;
         }
@@ -305,18 +306,18 @@ bool_t json_parse_boolean(const char* json_string, cereal_uint_t* i, bool_t* fai
             cereal_uint_t temp_i = *i;
             skip_whitespace(json_string, strlen(json_string), &temp_i);
             if (strncmp(&json_string[temp_i], "true", 4) == 0 || strncmp(&json_string[temp_i], "false", 5) == 0) {
-                strcat(error_text, "cerealize ERROR: Multiple boolean values not allowed.\n");
+                strcat(error_text, "cerialize ERROR: Multiple boolean values not allowed.\n");
                 *failure = TRUE;
                 return FALSE;
             }
             return FALSE;
         } else {
-            strcat(error_text, "cerealize ERROR: Unexpected characters after 'false'.\n");
+            strcat(error_text, "cerialize ERROR: Unexpected characters after 'false'.\n");
             *failure = TRUE;
             return FALSE;
         }
     } else {
-        strcat(error_text, "cerealize ERROR: Expected 'true' or 'false'.\n");
+        strcat(error_text, "cerialize ERROR: Expected 'true' or 'false'.\n");
         *failure = TRUE;
         return FALSE; // default return value
     }
@@ -328,11 +329,13 @@ json_list json_parse_list(const char* json_string, cereal_size_t length, cereal_
     skip_whitespace(json_string, length, i);
 
     if (json_string[*i] != LEX_OPEN_SQUARE) {
-        strcat(error_text, "cerealize ERROR: Expected opening square '[' for JSON list.\n");
+        strcat(error_text, "cerialize ERROR: Expected opening square '[' for JSON list.\n");
         *failure = TRUE;
         return (json_list){0, NULL}; // return empty list on error
     }
     (*i)++; // move past '['
+
+    int depth = 0;
 
     // count number of elements in the list
     cereal_size_t count = 0;
@@ -350,13 +353,13 @@ json_list json_parse_list(const char* json_string, cereal_size_t length, cereal_
         // json_object* value = malloc(sizeof(json_object));
         json_object value = parse_json_object(json_string, length, i, error_text, failure);
         if (*failure) {
-            strcat(error_text, "cerealize ERROR: Failed to parse value in JSON list.\n");
+            strcat(error_text, "cerialize ERROR: Failed to parse value in JSON list.\n");
             return (json_list){0, NULL};
         }
         // add value to list
         list = realloc(list, sizeof(json_object) * (count + 1));
         if (list == NULL) {
-            strcat(error_text, "cerealize ERROR: Failed to allocate memory for JSON list.\n");
+            strcat(error_text, "cerialize ERROR: Failed to allocate memory for JSON list.\n");
             *failure = TRUE;
             return (json_list){0, NULL};
         }
@@ -366,7 +369,7 @@ json_list json_parse_list(const char* json_string, cereal_size_t length, cereal_
         skip_whitespace(json_string, length, i);
     
         if (json_string[*i] != LEX_COMMA && json_string[*i] != LEX_CLOSE_SQUARE && *i != length) {
-            strcat(error_text, "cerealize ERROR: Expected ',' or ']' after value in JSON list.\n");
+            strcat(error_text, "cerialize ERROR: Expected ',' or ']' after value in JSON list.\n");
             *failure = TRUE;
             return (json_list){0, NULL};
         }
@@ -377,15 +380,17 @@ json_list json_parse_list(const char* json_string, cereal_size_t length, cereal_
 
         if (json_string[*i] == LEX_CLOSE_SQUARE) {
             found_closing_square = TRUE;
+            (*i)++; // move past ']'
             break;
         }
 
+        // skip whitespace before next item
         skip_whitespace(json_string, length, i);
     }
 
     // If we never found a closing square, this is an error
     if (!found_closing_square) {
-        strcat(error_text, "cerealize ERROR: Expected closing square ']' for JSON list.\n");
+        strcat(error_text, "cerialize ERROR: Expected closing square ']' for JSON list.\n");
         *failure = TRUE;
         if (list) free(list);
         return (json_list){0, NULL}; // return NULL on error
@@ -437,7 +442,7 @@ json_object parse_json_object(const char* json_string, cereal_size_t length, cer
 
     // parse build object
     if (cur != LEX_OPEN_BRACE) {
-        strcat(error_text, "cerealize ERROR: Expected opening brace '{' for JSON object.\n");
+        strcat(error_text, "cerialize ERROR: Expected opening brace '{' for JSON object.\n");
         *failure = TRUE;
         return (json_object){0}; // return empty value on error
     }
@@ -461,14 +466,14 @@ json_object parse_json_object(const char* json_string, cereal_size_t length, cer
 
         char* key = json_parse_string(json_string, length, i, failure, error_text);
         if (key == NULL) {
-            strcat(error_text, "cerealize ERROR: Failed to parse key in JSON object.\n");
+            strcat(error_text, "cerialize ERROR: Failed to parse key in JSON object.\n");
             *failure = TRUE;
             return (json_object){0}; // return empty value on error
         }
 
         skip_whitespace(json_string, length, i);
         if (json_string[*i] != LEX_COLON) {
-            strcat(error_text, "cerealize ERROR: Expected ':' after key in JSON object.\n");
+            strcat(error_text, "cerialize ERROR: Expected ':' after key in JSON object.\n");
             *failure = TRUE;
             free(key);
             return (json_object){0}; // return empty value on error
@@ -479,7 +484,7 @@ json_object parse_json_object(const char* json_string, cereal_size_t length, cer
 
         json_object value = parse_json_object(json_string, length, i, error_text, failure);
         if (*failure) {
-            strcat(error_text, "cerealize ERROR: Failed to parse value in JSON object.\n");
+            strcat(error_text, "cerialize ERROR: Failed to parse value in JSON object.\n");
             free(key);
             return (json_object){0}; // return empty value on error
         }
@@ -492,7 +497,7 @@ json_object parse_json_object(const char* json_string, cereal_size_t length, cer
         node_count++;
         head = realloc(head, sizeof(json_node) * node_count);
         if (head == NULL) {
-            strcat(error_text, "cerealize ERROR: Failed to allocate memory for JSON object.\n");
+            strcat(error_text, "cerialize ERROR: Failed to allocate memory for JSON object.\n");
             *failure = TRUE;
             free(key);
             return (json_object){0}; // return empty value on error
@@ -501,8 +506,10 @@ json_object parse_json_object(const char* json_string, cereal_size_t length, cer
         free(new_node);
 
         skip_whitespace(json_string, length, i);
-        if (json_string[*i] != LEX_COMMA && json_string[*i] != LEX_CLOSE_BRACE && *i != length) {
-            strcat(error_text, "cerealize ERROR: Expected ',' or '}' after key-value pair in JSON object.\n");
+        cur = json_string[*i];
+        bool_t is_valid_delimiter = (cur == LEX_COMMA || cur == LEX_CLOSE_BRACE || cur == LEX_CLOSE_SQUARE || *i == length);
+        if (!is_valid_delimiter) {
+            strcat(error_text, "cerialize ERROR: Expected ',' or '}' after key-value pair in JSON object.\n");
             *failure = TRUE;
             free(key);
             return (json_object){0}; // return empty value on error
@@ -524,7 +531,7 @@ json_object parse_json_object(const char* json_string, cereal_size_t length, cer
 
     // If we never found a closing brace, this is an error
     if (!found_closing_brace) {
-        strcat(error_text, "cerealize ERROR: Expected closing brace '}' for JSON object.\n");
+        strcat(error_text, "cerialize ERROR: Expected closing brace '}' for JSON object.\n");
         *failure = TRUE;
         if (head) free(head);
         return (json_object){0};
@@ -547,8 +554,8 @@ json deserialize_json(const char* json_string, cereal_size_t length) {
         json result = {
             .root = {0},
             .failure = TRUE,
-            .error_text = "cerealize ERROR: Failed to allocate memory for error text.\n",
-            .error_length = strlen("cerealize ERROR: Failed to allocate memory for error text.\n")
+            .error_text = "cerialize ERROR: Failed to allocate memory for error text.\n",
+            .error_length = strlen("cerialize ERROR: Failed to allocate memory for error text.\n")
         };
         return result;
     }
@@ -676,6 +683,16 @@ char* serialize_json(const json* j) {
         default:
             return NULL;
     }
+}
+
+json_object json_get_property(json_object obj, const char* key) {
+    for (cereal_size_t i = 0; i < obj.value.object.node_count; i++) {
+        json_node node = obj.value.object.nodes[i];
+        if (strcmp(node.key, key) == 0) {
+            return node.value;
+        }
+    }
+    return (json_object){ .type = JSON_NULL };
 }
 
 #endif

--- a/test/README.md
+++ b/test/README.md
@@ -1,14 +1,14 @@
 
 # Test Suite Documentation
 
-This directory contains the test suite for the cerealize project, which is focused on JSON serialization and deserialization in C. The tests verify both the parsing (deserialization) and generation (serialization) of JSON data. The suite is organized into separate files based on the type of data being tested. Below is an overview of the structure and contents of the test suite.
+This directory contains the test suite for the cerialize project, which is focused on JSON serialization and deserialization in C. The tests verify both the parsing (deserialization) and generation (serialization) of JSON data. The suite is organized into separate files based on the type of data being tested. Below is an overview of the structure and contents of the test suite.
 
 ## Project Structure
 
 The project is organized as follows:
 
-- **include/**: Contains public headers for the cerealize library.
-  - `cerealize.h`: Main header for JSON serialization/deserialization logic.
+- **include/**: Contains public headers for the cerialize library.
+  - `cerialize.h`: Main header for JSON serialization/deserialization logic.
 
 - **test/**: Contains the test suite and related files.
   - **cases/**: Individual test case files for different data types and features.
@@ -53,7 +53,7 @@ make
 
 ## Dependencies
 
-Ensure that you have the necessary development tools installed, including a C compiler (such as GCC) and any libraries required by the cerealize project. No external JSON libraries are required, as serialization and deserialization are implemented in C.
+Ensure that you have the necessary development tools installed, including a C compiler (such as GCC) and any libraries required by the cerialize project. No external JSON libraries are required, as serialization and deserialization are implemented in C.
 
 ## Contribution
 

--- a/test/cases/test_bool.h
+++ b/test/cases/test_bool.h
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#include "cerealize.h"
+#include "cerialize.h"
 #include "../helpers/test_utils.h"
 
 typedef struct {

--- a/test/cases/test_list.h
+++ b/test/cases/test_list.h
@@ -1,7 +1,7 @@
 #ifndef TEST_LIST_H
 #define TEST_LIST_H
 
-#include "../../include/cerealize.h"
+#include "../../include/cerialize.h"
 #include "../helpers/test_utils.h"
 #include "../helpers/test_output_helper.h"
 #include <assert.h>

--- a/test/cases/test_null.h
+++ b/test/cases/test_null.h
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#include "cerealize.h"
+#include "cerialize.h"
 #include "../helpers/test_utils.h"
 #include "../helpers/test_output_helper.h"
 

--- a/test/cases/test_number.h
+++ b/test/cases/test_number.h
@@ -2,7 +2,7 @@
 #include "../helpers/test_output_helper.h"
 #include <stdio.h>
 #include <string.h>
-#include "cerealize.h"
+#include "cerialize.h"
 
 typedef struct {
     const char* input;

--- a/test/cases/test_object.h
+++ b/test/cases/test_object.h
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#include "cerealize.h"
+#include "cerialize.h"
 #include "../helpers/test_utils.h"
 #include "../helpers/test_output_helper.h"
 

--- a/test/cases/test_serialize.h
+++ b/test/cases/test_serialize.h
@@ -1,7 +1,7 @@
 #ifndef TEST_SERIALIZE_H
 #define TEST_SERIALIZE_H
 
-#include "../../include/cerealize.h"
+#include "../../include/cerialize.h"
 #include "../helpers/test_utils.h"
 #include "../helpers/test_output_helper.h"
 #include <assert.h>

--- a/test/cases/test_string.h
+++ b/test/cases/test_string.h
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#include "cerealize.h"
+#include "cerialize.h"
 #include "../helpers/test_utils.h"
 #include "../helpers/test_output_helper.h"
 

--- a/test/helpers/test_utils.h
+++ b/test/helpers/test_utils.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include "cerealize.h"
+#include "cerialize.h"
 
 typedef struct { int passed, failed; size_t total; } test_summary_t;
 #ifndef TEST_UTILS_H
@@ -12,7 +12,7 @@ typedef struct { int passed, failed; size_t total; } test_summary_t;
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include "cerealize.h"
+#include "cerialize.h"
 
 #define EPSILON 1e-5
 #define ASSERT_TRUE(condition, message) \

--- a/test/tests.c
+++ b/test/tests.c
@@ -30,7 +30,7 @@ int main() {
     const char *CYAN = "\033[0;36m";
     const char *RESET = "\033[0m";
 
-    printf("%sRunning cerealize tests...%s\n", CYAN, RESET);
+    printf("%sRunning cerialize tests...%s\n", CYAN, RESET);
 
     test_summary_t string_summary = run_string_tests();
     test_summary_t number_summary = run_number_tests();


### PR DESCRIPTION
- Strings now use double quotes
  ```
  "example"
  ```
- Fix but regarding string reading
```
"id\x99"     // before
"id"         // now
```